### PR TITLE
Add Observability documentation section (Grafana, PostHog, OpenTelemetry)

### DIFF
--- a/docs/observability/1_observability-backend.md
+++ b/docs/observability/1_observability-backend.md
@@ -1,0 +1,34 @@
+---
+title: Observability backend: Grafana
+parent: Observability
+layout: default
+nav_order: 1
+---
+
+# Observability backend: Grafana
+
+Grafana isn't one piece — it's several, each covering a different signal, and they aren't interchangeable:
+
+| Piece | Signal | Notes |
+|---|---|---|
+| **Grafana** | Visualization | The dashboard. Stores nothing itself — reads from Loki, Tempo, and Prometheus/Mimir and displays them in one place. |
+| **Prometheus / Mimir** | Metrics | Numeric time series (CPU, requests/sec, latency). Prometheus scrapes a `/metrics` endpoint; Mimir is the scalable/multi-tenant version Grafana Cloud uses at volume. |
+| **Loki** | Logs | Indexes only metadata/labels, not full text — much cheaper to operate than Elasticsearch at the same volume. |
+| **Tempo** | Traces | The full path of a request across services, with per-hop timing. Stored on S3 to keep retention cheap. |
+| **Alloy** | Collection | The agent that runs alongside the app/server and forwards logs/metrics/traces to Loki/Prometheus/Tempo — one agent instead of one per signal. |
+
+Grafana is also not just for infrastructure: any simple business metric exposed as a counter/gauge (e.g. transactions processed) can be graphed on the same dashboard as infra metrics, with no separate BI tool needed for that kind of quantitative signal.
+
+## Self-hosted vs. Grafana Cloud
+
+Both are valid options — which one to use is a decision to make with the client, since pricing (self-hosted infra cost vs. Grafana Cloud's usage-based pricing) is the main factor between them and depends on the project's budget and expected volume.
+
+| | Self-hosted (LGTM stack) | Grafana Cloud (hybrid) |
+|---|---|---|
+| **Who operates it** | We do — install Loki/Tempo/Prometheus/Grafana on EC2/ECS, scale, update, back up, manage IAM | Grafana — nothing installed on our side |
+| **Effort** | High — four distributed systems to tune, scale, and upgrade | Low — same dashboards, no infrastructure of our own to operate |
+| **Deployment options on AWS** | (a) single EC2 (min. `t3.large`) with Docker Compose, for MVPs; (b) ECS Fargate with Alloy as a sidecar | App still runs on our own AWS infra; only the observability backend is managed |
+
+Grafana Cloud accepts OTLP directly from the app, with no Alloy collector in the middle — the first step into the hybrid model can be just changing two environment variables (endpoint + auth token), with zero new infrastructure. Alloy is the recommended path for production at real scale, but it isn't a requirement to get started.
+
+Whichever option is used, it doesn't change a line of application code: the app is instrumented with OpenTelemetry the same way in both cases, and only the collector's destination changes — see [Choosing a backend](./3_telemetry.md#choosing-a-backend) in the telemetry guide.

--- a/docs/observability/2_product-analytics.md
+++ b/docs/observability/2_product-analytics.md
@@ -1,0 +1,46 @@
+---
+title: Product analytics: PostHog
+parent: Observability
+layout: default
+nav_order: 2
+---
+
+# Product analytics: PostHog
+
+PostHog doesn't compete with Grafana — it competes with Amplitude, Mixpanel, Segment, GA4, and Heap on product analytics: events, funnels, session replay, feature flags, and A/B testing for **authenticated** product usage. It has no relationship to infrastructure health.
+
+> **Before integrating PostHog on a project, talk to the client.** Its pricing is usage-based (per event, replay, feature flag request, etc.), so adopting it — and later deciding what to track — is a conversation to have upfront, not an implementation detail to decide unilaterally.
+
+- **Model:** open-core (MIT), self-hosted or cloud.
+- **NestJS/Node integration:** `posthog-node` for server-side events, `posthog-js` for the frontend.
+- **All-in-one:** analytics + session replay + feature flags + experiments + error tracking + LLM observability + web analytics on a single product — every tool that isn't added separately is one less integration, login, and contract to maintain.
+
+## Implementation in the NestJS Template
+
+The [NestJS Template](https://github.com/SpaceUY/NestJS-Template) implements this as an abstract analytics module under `common/observability/analytics`, following the same [Adapter Pattern](../standard-definitions/2_nestjs-template.md) used for Email, Cloud Storage, and Push Notifications: a common abstract class defines the analytics interface, and provider-specific subclasses implement it.
+
+- **`PostHogAdapterService`** — the real adapter, backed by `posthog-node`, sends events to PostHog.
+- **`ConsoleAdapterService`** — logs events to the console instead of sending them anywhere. Used for local development and initial testing without needing a PostHog project configured.
+
+Because both sit behind the same abstract class, switching between them (or adding a new provider later) is a matter of swapping which adapter gets injected — the rest of the application only depends on the abstract interface.
+
+Inject the `AnalyticsService` token in other modules — never a concrete adapter class — so the adapter can be swapped without touching consumers. Its main methods:
+
+- **`capture(input)`** — sends a product event (e.g. "order created", "user upgraded plan") tied to a `distinctId`.
+- **`isFeatureEnabled(key, distinctId)`** — checks whether a boolean feature flag is on for a given user.
+- **`getFeatureFlag(key, distinctId)`** — reads a flag's value, including non-boolean/multivariate flags.
+
+## What to track from the backend
+
+Backend events are for things that need to be reliable and can't depend on the frontend actually running (ad blockers, closed tabs, failed requests) — typically business-critical or lifecycle events, for example:
+
+- Account/order lifecycle: `user signed up`, `order created`, `payment succeeded` / `payment failed`, `subscription upgraded` / `downgraded` / `cancelled`.
+- Background/async outcomes: a queued job finishing (report generated, export ready, webhook received from a third party).
+- Security-sensitive actions: `password reset requested`, `MFA enabled`, `API key created` / `revoked`.
+- Server-side feature flag checks that gate business logic (not just UI), so you can see which variant actually ran for a given request.
+
+Which events to track should be agreed with the client — PostHog's pricing is usage-based per event, so tracking everything by default can turn into a real cost driver. Decide with the client which events matter for their product/business rather than instrumenting every possible action.
+
+## Web analytics
+
+PostHog also offers Web Analytics — anonymous traffic/marketing metrics (pageviews, UTM sources, bounce rate), as opposed to the authenticated product usage covered above. It's instrumented on the frontend — see the [React Guidelines](https://spaceuy.github.io/react-guidelines) for the standard there.

--- a/docs/observability/3_telemetry.md
+++ b/docs/observability/3_telemetry.md
@@ -1,0 +1,146 @@
+---
+title: "Telemetry: OpenTelemetry instrumentation in NestJS"
+parent: Observability
+layout: default
+nav_order: 3
+---
+
+# Telemetry: OpenTelemetry instrumentation in NestJS
+
+This is the practical, code-level piece of the observability standard: how to think about tracing with [OpenTelemetry](https://opentelemetry.io/) in a NestJS service, independent of which backend ([Grafana](./1_observability-backend.md), SigNoz, Datadog, etc.) ends up reading the data. It has already been implemented and validated in the [NestJS Template](https://github.com/SpaceUY/NestJS-Template), under `common/observability/telemetry`.
+
+## The goal: instrument once, not again for the next incident
+
+"Observable" means: when an unknown failure mode shows up in production, you can answer "why" from the data you're already collecting — not by SSH-ing in, adding a `console.log`, and redeploying. That means capturing high-cardinality context up front, because you can't predict which attribute will matter for a bug you haven't seen yet.
+
+## Traces first, then logs, then metrics
+
+**Logs** are events you decided in advance were worth recording, with whatever fields occurred to you at the time. **Traces** capture the actual shape of a request's execution — every hop, every dependency call, with timing — and context is attached as attributes you can filter on after the fact, not before.
+
+For a team starting from "configurable logger, no tracing," the highest-impact order is: **traces first → wire the existing logger to emit trace context → metrics last.** Metrics without traces tell you something is wrong. Traces without metrics still let you find out why. The reverse is much less true.
+
+## Auto-instrumentation is the floor, not the ceiling
+
+Auto-instrumentation packages patch common libraries (HTTP in/out, `pg`, Redis, etc.) to emit spans automatically, with no code changes. It gives immediate infrastructure visibility: every HTTP call and DB query becomes a span. It's the first step, and the highest return for the effort. We only register the specific instrumentations our stack actually uses — see [Bootstrap implementation](#bootstrap-implementation) below.
+
+It does not capture the shape of your business logic: it tells you "an HTTP call to the payments service took 400ms," not "we spent 300ms recalculating the user's discount tier for this edge case." That needs manual spans around meaningful units of work — service methods, use-case handlers, the seams of your domain.
+
+## A method is a unit of work — but not every method deserves a span
+
+A span represents a unit of work with a start, an end, and a meaningful name — something that deserves its own bar in a waterfall view. NestJS service methods are usually already factored this way: `OrdersService.createOrder()`, `PaymentService.chargeCard()`, `DiscountService.calculateTier()`.
+
+Span a method if at least one of these is true:
+
+- It crosses a process/IO boundary (DB, HTTP, queue publish) — though auto-instrumentation usually already covers this.
+- It represents a distinct business step worth measuring on its own ("tier calculation took 280ms" is useful; "the private helper that adds two numbers took 0.001ms" is not).
+- It's a place where you'll attach attributes only known/computed there (`discount.tier`, `payment.provider`, `order.itemCount`) — even if the method is fast, the attribute is the value, not the timing.
+- It's a branch point you actually debug in practice — somewhere you'd ask "which path did this take?"
+
+Don't span: pure functions/private helpers with no IO or decision-relevant state, trivial getters/mappers/DTOs, or anything called inside a tight loop (wrap the loop itself in one span with an `items.count` attribute instead of N spans).
+
+## Two implementation layers
+
+**Layer 1 — free:** a NestJS interceptor wraps handler execution (or any DI-managed provider) in a span automatically, named by class/method, with no per-method code. Gives trace boundaries for every entry point at zero ongoing effort. This layer is already covered by the official `@opentelemetry/instrumentation-nestjs-core` package (imported as `NestInstrumentation`) — no in-house interceptor needed.
+
+**Layer 2 — intentional:** explicit instrumentation inside the methods chosen per the criteria above — grab the active span and add attributes/events, or open a child span if the method has sub-steps worth separating. In-house pattern: a `@Span()` decorator (~20 lines, depends only on `@opentelemetry/api`) that wraps the method in `tracer.startActiveSpan(...)`, records exceptions and error status, closes the span in a `finally`, and lets the method body call `trace.getActiveSpan()?.setAttribute(...)` to attach business data.
+
+## No third-party NestJS wrapper
+
+Two community wrappers were evaluated and discarded: `amplication/opentelemetry-nestjs` and `pragmaticivan/nestjs-otel`. Both show the same abandonment pattern as the forks they replaced (e.g. last release March 2024, fork-of-a-fork lineage). No NestJS OTel wrapper lives under the official `open-telemetry` GitHub org — that's a project design decision, not an oversight specific to NestJS.
+
+Use only official packages:
+
+- `@opentelemetry/instrumentation-nestjs-core` (`NestInstrumentation`) for automatic controller/guard/interceptor/pipe spans.
+- A small in-house `@Span()` decorator for manual spans, depending only on `@opentelemetry/api` — the most stable package in the ecosystem.
+- Explicitly-named instrumentations (`HttpInstrumentation`, `PgInstrumentation`, `IORedisInstrumentation`, etc.) instead of the `auto-instrumentations-node` meta-bundle, which pulls in ~50 instrumentations for libraries not in our stack (Kafka, Cassandra, GraphQL...).
+
+## Bootstrap implementation
+
+This is what `common/observability/telemetry` in the NestJS Template looks like — it builds the SDK explicitly instead of pulling in `@opentelemetry/auto-instrumentations-node`:
+
+```ts
+import { NodeSDK } from '@opentelemetry/sdk-node';
+import { resourceFromAttributes } from '@opentelemetry/resources';
+import { ATTR_SERVICE_NAME } from '@opentelemetry/semantic-conventions';
+import { OTLPTraceExporter } from '@opentelemetry/exporter-trace-otlp-http';
+import { HttpInstrumentation } from '@opentelemetry/instrumentation-http';
+import { NestInstrumentation } from '@opentelemetry/instrumentation-nestjs-core';
+import { PgInstrumentation } from '@opentelemetry/instrumentation-pg';
+import { IORedisInstrumentation } from '@opentelemetry/instrumentation-ioredis';
+import { getOtelConfig, OtelConfig } from './otel-env';
+
+export function buildSdk(config: OtelConfig): NodeSDK | null {
+  if (!config.enabled) return null;
+
+  return new NodeSDK({
+    resource: resourceFromAttributes({
+      [ATTR_SERVICE_NAME]: config.serviceName,
+    }),
+    traceExporter: new OTLPTraceExporter({
+      url: config.endpoint,
+      headers: config.headers,
+    }),
+    instrumentations: [
+      new HttpInstrumentation(),
+      new NestInstrumentation(),
+      new PgInstrumentation(),
+      new IORedisInstrumentation(),
+    ],
+  });
+}
+
+const sdk = buildSdk(getOtelConfig());
+
+if (sdk) {
+  sdk.start();
+
+  process.on('SIGTERM', () => {
+    sdk
+      .shutdown()
+      .catch((err: unknown) => {
+        console.error('Error shutting down OpenTelemetry SDK', err);
+      })
+      .finally(() => process.exit(0));
+  });
+}
+```
+
+`getOtelConfig()` derives `config.enabled` from whether `OTEL_EXPORTER_OTLP_ENDPOINT` is set — if it isn't, `buildSdk` returns `null` and the app starts exactly as it would without OTel. This file is the dedicated bootstrap entrypoint referenced below: it has to be imported before anything else.
+
+## The most common mistake: initialization order
+
+The Node OTel SDK relies on `AsyncLocalStorage` to track the active span across async boundaries, which works fine with Nest's DI and lifecycle. The real gotcha is different: auto-instrumentation patches modules at `require`/`import` time, so **the SDK must initialize before anything else is imported**. The typical bug is initializing OTel inside `main.ts` after other imports have already loaded. Use a dedicated bootstrap file, loaded first (via `--require`, or as the literal first import of the entrypoint) — e.g. `tracing.bootstrap.ts` imported as the first line of `main.ts`.
+
+## Logging becomes the span's narrator
+
+Two concrete changes:
+
+1. **Inject `trace_id`/`span_id` into every log line** — pull the active span from context in your logger (interceptor, middleware, or a log processor) and attach its IDs to every entry. This is the single biggest upgrade over logging blind: instead of loose lines, you open the trace and see every log emitted during that span.
+2. **Prefer span attributes/events over log lines for structured data.** Logs are better for unstructured narrative ("retrying after backoff"); attributes are better for anything you'll later filter or group by (`user.tier`, `payment.amount`, `cache.hit`). A log line like "user 4821 hit the rate limit" is far less useful than a span attribute `user.id=4821` you can pivot on across thousands of traces in the backend's UI.
+
+In the template, this is implemented as a `TraceContextLoggerDecorator` that wraps the configured logger adapter (Nest/Pino/Winston, unchanged) to stamp `traceId`/`spanId` on every log line and forward the log as `span.addEvent()`.
+
+## Sampling: a deliberate decision, not a default
+
+**Head-based:** decide at request start (e.g. keep 10%). Simple, but you can silently drop the one trace you needed. **Tail-based:** decide after the request finishes (e.g. keep all errors and slow requests, sample the rest). Closer to "never need to instrument again," but requires an OTel Collector in the path instead of exporting straight from the SDK to the backend.
+
+To start: export everything during the initial rollout, introduce sampling once volume becomes a cost problem. Don't optimize this ahead of time.
+
+## Choosing a backend
+
+The OTel SDK is vendor-neutral (OTLP exporter) — instrumentation code only ever talks to `OTEL_EXPORTER_OTLP_ENDPOINT`/`OTEL_EXPORTER_OTLP_HEADERS`, never to a specific vendor's SDK. That's the practical payoff of standardizing on OpenTelemetry: which backend to use is a separate, genuinely reversible decision — see [Observability backend](./1_observability-backend.md) for how we choose and set it up (self-hosted Grafana vs. Grafana Cloud). If that choice changes later, moving to it is a config change (updating the endpoint and headers), not a rewrite of the instrumentation.
+
+To start locally: [Jaeger](https://www.jaegertracing.io/) (`jaegertracing/all-in-one`) added to `docker-compose.yml` — UI on `:16686`, OTLP HTTP on `:4318`. Moving from local Jaeger to the chosen backend later doesn't touch a line of instrumentation code — only the collector's destination changes.
+
+## What's already done vs. what's next
+
+**Done** (`common/observability/telemetry` in the NestJS Template): SDK bootstrap with explicitly-named official instrumentations, no third-party wrapper, the `@Span()` decorator, two-way log correlation via `TraceContextLoggerDecorator`, and a local Jaeger backend in `docker-compose.yml`.
+
+**Next, when a project needs it:**
+
+- Apply `@Span()` to paths that would page someone if they broke, using the criteria above — the decorator exists and is tested, but deliberately isn't applied to any real method yet without a concrete use case.
+- Add span attributes liberally on those manual spans — over-attributing now is cheaper than guessing later.
+- Migrate the backend from local Jaeger to Grafana Cloud or Amazon Managed Grafana + Prometheus — config-only change.
+- Add metrics only for what you'll actually alert on (latency SLOs, error rates) — last, not first.
+- Revisit sampling once real volume/cost shape is understood.
+- Audit PostHog event volume against the active pricing tier — usage-based pricing at scale is the most concrete cost risk identified.

--- a/docs/observability/index.md
+++ b/docs/observability/index.md
@@ -1,0 +1,25 @@
+---
+title: Observability
+layout: default
+nav_order: 3
+---
+
+# Observability
+
+This section covers how to make a NestJS backend observable: infrastructure/application monitoring via **Grafana**, product analytics via **PostHog**, and how to instrument a NestJS service with **OpenTelemetry** so both are fed correctly. Infrastructure provisioning on AWS (how the observability backend is actually deployed) is covered in the [DevOps Guidelines](https://github.com/SpaceUY/devops-guidelines) — this section is the application-level standard.
+
+1. [Observability backend: Grafana](./1_observability-backend.md)
+2. [Product analytics: PostHog](./2_product-analytics.md)
+3. [Telemetry: OpenTelemetry instrumentation in NestJS](./3_telemetry.md)
+
+## Recommended stack
+
+| Layer | Tool | Role |
+|---|---|---|
+| **Telemetry** | [OpenTelemetry](https://opentelemetry.io/) | Generates traces, logs, and metrics from inside the app in a vendor-neutral way. Decouples the code from whichever backend reads that data. |
+| **Observability backend** | [Grafana Cloud](https://grafana.com/products/cloud/) (hybrid model) | Managed Tempo (traces) + Loki (logs) + Prometheus/Mimir (metrics), read through Grafana dashboards. |
+| **Product analytics** | [PostHog](https://posthog.com/) | Events, funnels, session replay, feature flags, experiments, and web analytics for authenticated product usage. |
+
+## Why this stack
+
+This is not a decision made in a vacuum — see the full [Observability & Product Analytics research](https://claude.ai/code/artifact/5a3b6cdf-7cef-44ec-9de6-9b34bc883961) for the complete provider-by-provider comparison this summary is based on.

--- a/docs/standard-definitions/1_standard-definitions.md
+++ b/docs/standard-definitions/1_standard-definitions.md
@@ -14,6 +14,7 @@ The following standards have been defined at the company level through chapter m
 - **Non-Relational ORM:** [Mongoose](https://mongoosejs.com/) is the preferred choice for working with non-relational (NoSQL) databases.
 - **Backend Framework:** [NestJS](https://nestjs.com/) is our standard backend framework for building scalable server-side applications.
 - **Infrastructure:** [AWS](https://aws.amazon.com/) is our standard platform for cloud infrastructure and services. See the [DevOps Guidelines](https://github.com/SpaceUY/devops-guidelines) for deployment and infrastructure documentation.
+- **Observability:** [Grafana](https://grafana.com/) (self-hosted or Grafana Cloud) for infrastructure/application monitoring, [PostHog](https://posthog.com/) for product analytics, and [OpenTelemetry](https://opentelemetry.io/) for instrumenting the backend. See the [Observability section](../observability/index.md) for the full standard.
 - **Chapter Board:** We use the [ClickUp chapter NestJS board](https://app.clickup.com/3117051/v/o/s/90142470417) to manage and track chapter-related activities and standards.
 - **Authentication:** [Auth0](https://auth0.com/) is the standard solution for authentication and authorization.
 - **Repository Hosting:** [Bitbucket](https://bitbucket.org/) is our standard platform for hosting code repositories.

--- a/docs/standard-definitions/index.md
+++ b/docs/standard-definitions/index.md
@@ -1,7 +1,7 @@
 ---
 title: Company’s Standard Technology Definitions
 layout: default
-nav_order: 1
+nav_order: 0.5
 ---
 
 # Company’s standard technology definitions

--- a/index.md
+++ b/index.md
@@ -1,6 +1,7 @@
 ---
 title: Home
 layout: default
+nav_order: 0
 ---
 
 # Welcome to the Nest JS Code Guidelines!
@@ -36,6 +37,7 @@ Here's a sneak peek of what we cover:
 - **Common Pitfalls**: Mistakes to avoid and how to fix them.
 - **Useful Tools**: Recommended tools and libraries that make our lives easier.
 - **Notifications**: Implementing push notifications with Firebase Cloud Messaging from the backend.
+- **Observability**: Our recommended stack (Grafana Cloud + PostHog + OpenTelemetry) and how to instrument a NestJS service with OpenTelemetry.
 
 ## Let's Make It Happen!
 


### PR DESCRIPTION
Description:

Adds a new Observability section to the NestJS guidelines: infrastructure monitoring with Grafana (self-hosted vs. Grafana Cloud), product analytics with PostHog, and backend instrumentation with OpenTelemetry. Also links the new section from standard-definitions and the site home.

Type of change: Documentation (new section)

Changelog:

docs/observability/1_observability-backend.md — Grafana self-hosted (LGTM stack) vs. Grafana Cloud, deployment tradeoffs.
docs/observability/2_product-analytics.md — PostHog integration via the Adapter pattern (PostHogAdapterService / ConsoleAdapterService), what to track from the backend.
docs/observability/3_telemetry.md — OpenTelemetry instrumentation guide: auto- vs. manual spans, @Span() decorator, bootstrap order, log/trace correlation, sampling, backend choice.
docs/observability/index.md — section index and recommended stack.
Linked from standard-definitions/1_standard-definitions.md and index.md.